### PR TITLE
Added xterm-256color to the case statement

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -108,7 +108,7 @@ fi
    
 # If this is an xterm set the title
 case "$TERM" in
-cygwin|xterm|screen|linux|screen.linux)
+cygwin|xterm|xterm-256color|screen|linux|screen.linux)
 
     if [ "$OS" = "Windows_NT" ]; then
         # msys is *really* slow, so we have to make some concessions here    


### PR DESCRIPTION
New versions of GNOME Terminal set xterm-256color as default $TERM variable, adding it to the case statement solves the problem of colours missing from the bash prompt.
![term](https://cloud.githubusercontent.com/assets/1104584/15634436/75493638-25bb-11e6-8a9d-806670830034.png)
